### PR TITLE
use exact bitdepth integers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ license = "Zlib OR Apache-2.0 OR MIT"
 [dependencies]
 magnesium = "1.2"
 tinyvec = { version = "1", features = ["alloc"] }
-chlorine = "1"
 
 [profile.release]
 lto = "thin"

--- a/src/gl_core_types.rs
+++ b/src/gl_core_types.rs
@@ -5,7 +5,7 @@ use super::*;
 /// A GL enumeration value.
 #[derive(PartialEq, Eq, Hash)]
 #[repr(transparent)]
-pub struct GLenum(pub c_uint);
+pub struct GLenum(pub u32);
 impl core::fmt::Debug for GLenum {
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
     write!(f, "GlEnum(0x{:X})", self.0)
@@ -23,7 +23,7 @@ impl Copy for GLenum {}
 /// You can mix around the bits of these values using standard bitwise ops.
 #[derive(PartialEq, Eq, Hash)]
 #[repr(transparent)]
-pub struct GLbitfield(pub c_uint);
+pub struct GLbitfield(pub u32);
 impl core::fmt::Debug for GLbitfield {
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
     write!(f, "GlBitfield(0b{:b})", self.0)
@@ -77,7 +77,7 @@ impl core::ops::Not for GLbitfield {
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 #[repr(transparent)]
-pub struct GLhandleARB(#[cfg(any(target_os = "ios", target_os = "macos"))] pub *mut void, #[cfg(not(any(target_os = "ios", target_os = "macos")))] pub c_uint);
+pub struct GLhandleARB(#[cfg(any(target_os = "ios", target_os = "macos"))] pub *mut void, #[cfg(not(any(target_os = "ios", target_os = "macos")))] pub GLuint);
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 #[repr(transparent)]
@@ -109,29 +109,29 @@ pub type GLVULKANPROCNV = Option<unsafe extern "system" fn()>;
 // them just for use within the crate. Since they aren't world-visible, the
 // outside world will show the base Rust type on function arguments.
 
-pub(crate) type GLboolean = c_uchar;
+pub(crate) type GLboolean = bool;
 pub(crate) type GLbyte = i8;
 pub(crate) type GLcharARB = u8;
-pub(crate) type GLclampd = c_double;
-pub(crate) type GLclampf = c_float;
+pub(crate) type GLclampd = f64;
+pub(crate) type GLclampf = f32;
 pub(crate) type GLclampx = i32;
-pub(crate) type GLdouble = c_double;
+pub(crate) type GLdouble = f64;
 pub(crate) type GLfixed = i32;
-pub(crate) type GLfloat = c_float;
+pub(crate) type GLfloat = f32;
 pub(crate) type GLhalf = u16;
 pub(crate) type GLhalfARB = u16;
-pub(crate) type GLhalfNV = c_ushort;
-pub(crate) type GLint = c_int;
+pub(crate) type GLhalfNV = u16;
+pub(crate) type GLint = i32;
 pub(crate) type GLint64 = i64;
 pub(crate) type GLint64EXT = i64;
 pub(crate) type GLintptr = isize;
 pub(crate) type GLintptrARB = isize;
 pub(crate) type GLshort = i16;
-pub(crate) type GLsizei = c_int;
+pub(crate) type GLsizei = u32;
 pub(crate) type GLsizeiptr = isize;
 pub(crate) type GLsizeiptrARB = isize;
 pub(crate) type GLubyte = u8;
-pub(crate) type GLuint = c_uint;
+pub(crate) type GLuint = u32;
 pub(crate) type GLuint64 = u64;
 pub(crate) type GLuint64EXT = u64;
 pub(crate) type GLushort = u16;

--- a/src/gl_enumerations.rs
+++ b/src/gl_enumerations.rs
@@ -4388,7 +4388,7 @@ pub const GL_INVALID_FRAMEBUFFER_OPERATION_EXT: GLenum = GLenum(0x0506);
 
 pub const GL_INVALID_FRAMEBUFFER_OPERATION_OES: GLenum = GLenum(0x0506);
 
-pub const GL_INVALID_INDEX: c_uint = 0xFFFFFFFF;
+pub const GL_INVALID_INDEX: GLuint = 0xFFFFFFFF;
 
 pub const GL_INVALID_OPERATION: GLenum = GLenum(0x0502);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@
 //! it exposes by at least preventing you from accidentally mixing up `GLenum`,
 //! `GLbitfield`, and plain integer values.
 
-use chlorine::*;
 use magnesium::{XmlElement::*, *};
 
 use core::fmt::Write;


### PR DESCRIPTION
OpenGL actually specifies the exact bitdepth of its data types, as seen in [Khronos OpenGL documentation]!
`GLboolean` should be conveniently equivalent to Rust's `bool`.
Also even cleaner compilation without `chlorine`!
Documentation will look nicer and more consistent.
If I'm doing something wrong, please let me know.
Oh and btw, whatever happened to `no_std` support?

[Khronos OpenGL documentation]: https://www.khronos.org/opengl/wiki/OpenGL_Type